### PR TITLE
Make AMI pipeline installable with pip directly.

### DIFF
--- a/AMI/AMI_SIM_MTL/README.md
+++ b/AMI/AMI_SIM_MTL/README.md
@@ -154,6 +154,6 @@ This should produce the simulation(s) as defined in the yaml file.
 Otherwise if you have set the $PATH correctly then you should be able to just 
 run the following from the command line:
 
-    wrapper.py --config=../inputs/example.yaml
+    wrapper --config=../inputs/example.yaml
 
 

--- a/AMI/AMI_SIM_MTL/README.md
+++ b/AMI/AMI_SIM_MTL/README.md
@@ -17,7 +17,7 @@ This will create an ami_sim directory in your current working directory.
 Please note down the AMISIM installation location you will need to for the 
 yaml file. From this point on we will refer to this as `{AMISIM_ROOT}`.
 
-All required python modules are installed with the `requirements.txt` file for 
+All required python modules are installed with the `setup.cfg` file for 
 the AMI Simulation wrapper (section \ref{sec:ami_sim_wrapper}). 
 However one of the modules (webbpsf) requires some additional files to be 
 downloaded and link to via an environmental variable. 
@@ -50,9 +50,7 @@ To clone the AMI Simulation wrapper use the following command:
 
     git clone git@github.com:njcuk9999/jwst-mtl.git
 
-This should create a directory called `jwst-mtl`. Please note down this 
-installation location you will need to for the yaml file. From this point on 
-we will refer to this as `{WRAPPER_ROOT}`.
+This should create a directory called `jwst-mtl`.
 
 We next recommend a new conda environment (though venv or pip can be used if you prefer).
 
@@ -70,7 +68,7 @@ directory that was created when you cloned the repository above.
 
     cd jwst-mtl/AMI/AMI_SIM_MTL
 
-Once in this directory you should see a `requirements.txt` file.
+Once in this directory you should see a `setup.cfg` file.
 
 Check that you have pip and are in the correct conda environment (if using 
 conda) using the following command:
@@ -83,19 +81,17 @@ It should display something ending in `/envs/ami-env/bin/pip`
 You can now install the python modules required for the AMI simulation wrapper 
 with the following command:
 
-    pip install -r requirements.txt
+    pip install .
 
-Finally we can add the AMI simulation wrapper to the python path by adding the 
-following to the `.bashrc`, `.profile`, `.login` or equivalent file. 
-Note we assume you are using the bash shell, this command may be different for 
-different command line shells.
+To install for development, you can install in editable mode and add the "dev"
+dependencies.
 
-    export PYTHONPATH={WRAPPER_ROOT}:$PYTHONPATH
-    export PATH={WRAPPER_ROOT}/bin/:$PATH
+    pip install -e ".[dev]"
 
-This will allow you to run and call the wrapper from within python or call the 
-wrapper function from the command line. If successful you are ready to set 
-up the simulation yaml file and then run the simulation wrapper.
+This will allow you to run and call the wrapper from within python or call the
+wrapper function from the command line, when working in the virtual environment
+created above. If successful you are ready to set up the simulation yaml file
+and then run the simulation wrapper.
 
 ### 3.2 The simulation yaml file
 

--- a/AMI/AMI_SIM_MTL/README.md
+++ b/AMI/AMI_SIM_MTL/README.md
@@ -4,9 +4,9 @@
 
 ## 1 AMISIM
 
-Installing AMISIM requires the of cloning the github repository and installing 
-some python modules (we handle the python modules as part of the requirements 
-to run the AMI simulation wrapper.
+Installing AMISIM requires cloning the github repository and installing some
+python modules (we handle the python modules as part of the requirements) to run
+the AMI simulation wrapper.
 
 To clone AMISIM use the following command:
 
@@ -77,7 +77,7 @@ conda) using the following command:
 
     which pip
 
-It should display something ending in `/envs/ami-env/bion/pip`
+It should display something ending in `/envs/ami-env/bin/pip`
 
 
 You can now install the python modules required for the AMI simulation wrapper 

--- a/AMI/AMI_SIM_MTL/pyproject.toml
+++ b/AMI/AMI_SIM_MTL/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "setuptools_scm"]
+build-backend = 'setuptools.build_meta'

--- a/AMI/AMI_SIM_MTL/setup.cfg
+++ b/AMI/AMI_SIM_MTL/setup.cfg
@@ -1,0 +1,22 @@
+[metadata]
+name = ami_mtl
+description = UdeM AMI Simulation wrapper
+long_description = file: README.md
+author = Neil Cook
+author_email = neil.james.cook@gmail.com
+url = https://github.com/njcuk9999/jwst-mtl/tree/master/AMI/AMI_SIM_MTL
+license = MIT License
+
+[options]
+zip_safe = False
+packages = find:
+install_requires =
+    mirage==2.2.1
+
+[options.extras_require]
+dev =
+    ipython
+
+[options.entry_points]
+console_scripts =
+    wrapper = ami_mtl.science.wraper:main

--- a/AMI/AMI_SIM_MTL/setup.cfg
+++ b/AMI/AMI_SIM_MTL/setup.cfg
@@ -19,4 +19,4 @@ dev =
 
 [options.entry_points]
 console_scripts =
-    wrapper = ami_mtl.science.wraper:main
+    wrapper = ami_mtl.science.wrapper:main

--- a/AMI/AMI_SIM_MTL/setup.py
+++ b/AMI/AMI_SIM_MTL/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+# Cannot just use True for scm because we are in git subdir
+setup(use_scm_version={"root": "../../", "relative_to": __file__})

--- a/AMI/tools_installation_ami.md
+++ b/AMI/tools_installation_ami.md
@@ -57,7 +57,7 @@ pyami/simcode/
 ### Questions:
 Why do we need a scene that is an odd number of pixels?
 Isn’t better to have psf x scene that is a power of 2 the number of pixels?
-Why is -utr 1 does not increase the number of images in the cube with driver_scene.py? Because the output product is the processed cube of integrations (CDS - dark - background)*ff, not raw data. 
+Why is -utr 1 does not increase the number of images in the cube with `driver_scene.py`? Because the output product is the processed cube of integrations (CDS - dark - background)\*ff, not raw data. 
 
 ---
 

--- a/AMI/tools_installation_ami.md
+++ b/AMI/tools_installation_ami.md
@@ -134,8 +134,12 @@ When run at the prompt, no image is displayed on screen. Anthony works in Spyder
 
 [http://fmillour.com/wp-content/uploads/Manuscrit_final.pdf](http://fmillour.com/wp-content/uploads/Manuscrit_final.pdf)
 
+## AMICAL
 
-## The “Sydney” IDL pipeline
+AMICAL is a Python rewrite of the IDL pipeline desribed below. It is hosted
+here: https://github.com/SydneyAstrophotonicInstrumentationLab/AMICAL.
+
+### The “Sydney” IDL pipeline
 
 Latest working version is here: [https://github.com/AnthonyCheetham/idl_masking/](https://github.com/AnthonyCheetham/idl_masking/)
 
@@ -150,7 +154,7 @@ Fit a model (binary_gri.pro)
 
 The arts of extracting the measurements is in calc_bispect. The bispectrum is the multiplication of three complex points `FFT(u_i,v_i)*FFT(u_j,v_j)*conj(FFT(u_k,v_k)).`
 
-Calc_bispec.pro calls bispect
+`Calc_bispec.pro` calls bispect
 
 ---
 

--- a/AMI/tools_installation_ami.md
+++ b/AMI/tools_installation_ami.md
@@ -9,7 +9,7 @@ Take from here: [https://docs.google.com/document/d/1Et1MuJjIYzh47M9_41RmO2ZOidC
 
 Install via git clone:
 ```bash
-git clone https://github.com/agreenbaum/ami_sim
+git clone https://github.com/anand0xff/ami_sim
 ```
 
 python requirements:


### PR DESCRIPTION
I created the required setup files (`setup.py`, `setup.cfg` and `pyproject.toml`) to install the AMI pipeline with `pip install .`. This removes the need to add anythign in the user's shell config, because `wrapper.main` is specified as an entry point in `setup.cfg`. I also updated the README instructions accordingly.